### PR TITLE
change base64 library and fixed signature

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("commons-codec" % "commons-codec" % "1.6")


### PR DESCRIPTION
when the string is too long, current version of base64 will add newline to the string which is not url safe. 

secondly, according to this https://developer.atlassian.com/static/connect/docs/concepts/understanding-jwt.html the last encoded signature is wrong. 

> Concatenate the encoded header, a period character (.) and the encoded claims set. That gives you signingInput = encodedHeader+ "." + encodedClaims.
> Compute the signature of signingInput using the JWT or cryptographic library of your choice. Then base64 encode it. That gives you encodedSignature.
> concatenate the signing input, another period character and the signature, which gives you the JWT token. jwtToken = signingInput + "." + encodedSignature
