### PR TITLE
Missing base64 encoding when generating signature

### DIFF
--- a/src/main/scala/authentikat/jwt/JsonWebToken.scala
+++ b/src/main/scala/authentikat/jwt/JsonWebToken.scala
@@ -22,7 +22,8 @@ object JsonWebToken {
 
     val signingInput = encodedHeader + "." + encodedClaims
 
-    val encodedSignature: String = JsonWebSignature(header.algorithm.getOrElse("none"), signingInput, key)
+    val encodedSignature: String = encodeBase64URLSafeString(
+        JsonWebSignature(header.algorithm.getOrElse("none"), signingInput, key))
 
     signingInput + "." + encodedSignature
   }
@@ -73,7 +74,8 @@ object JsonWebToken {
     val headerJsonString = new String(decodeBase64(sections(0)), "UTF-8")
     val header = JwtHeader.fromJsonString(headerJsonString)
 
-    val signature = JsonWebSignature(header.algorithm.getOrElse("none"), sections(0) + "." + sections(1), key)
+    val signature = encodeBase64URLSafeString(
+        JsonWebSignature(header.algorithm.getOrElse("none"), sections(0) + "." + sections(1), key))
 
     sections(2).contentEquals(signature)
   }

--- a/src/test/scala/authentikat/jwt/JsonWebTokenSpec.scala
+++ b/src/test/scala/authentikat/jwt/JsonWebTokenSpec.scala
@@ -31,7 +31,7 @@ class JsonWebTokenSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should produce the same results for all three claims types") {
-      val expectedResult = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJIZXkiOiJmb28ifQ.7d35bd7f6c39a244a96bbbbae1dea569041ba41760a1316f20f731e608bbd11f"
+      val expectedResult = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJIZXkiOiJmb28ifQ.fTW9f2w5okSpa7u64d6laQQbpBdgoTFvIPcx5gi70R8"
 
       val res1 = JsonWebToken.apply(header, JwtClaimsSetMap(Map("Hey" -> "foo")), "secretkey")
       val res2 = JsonWebToken.apply(header, JwtClaimsSetJValue(("Hey" -> "foo")), "secretkey")


### PR DESCRIPTION
`JsonWebSignature` needs to be encoded with base64.  Verify it with http://jwt.io/ 
Sorry for not catching this the first time. 
