### PR TITLE
Handle invalid JWT input more elegantly

### DIFF
--- a/src/main/scala/authentikat/jwt/JwtHeader.scala
+++ b/src/main/scala/authentikat/jwt/JwtHeader.scala
@@ -4,6 +4,7 @@ import authentikat.json.SimpleJsonSerializer
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
+import util.control.Exception.allCatch
 
 case class JwtHeader(algorithm: Option[String],
                      contentType: Option[String],
@@ -37,5 +38,9 @@ object JwtHeader {
     val typ = (ast \ "typ").extract[Option[String]]
 
     JwtHeader(alg, cty, typ)
+  }
+
+  def fromJsonStringOpt(jsonString: String): Option[JwtHeader] = allCatch opt {
+    fromJsonString(jsonString)
   }
 }

--- a/src/test/scala/authentikat/json/JsonSerializerSpec.scala
+++ b/src/test/scala/authentikat/json/JsonSerializerSpec.scala
@@ -14,7 +14,7 @@ class JsonSerializerSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should produce json with dates formatted as ISO8601") {
-      val date = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2011-01-01 00:00:00")
+      val date = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss Z").parse("2011-01-01 00:00:00 -0500")
       val stuffToSerialize = Seq(("key1", "value1"), ("key2", date))
 
       SimpleJsonSerializer(stuffToSerialize) should equal( """{"key1":"value1","key2":"2011-01-01T05:00Z"}""")

--- a/src/test/scala/authentikat/jwt/JsonWebTokenSpec.scala
+++ b/src/test/scala/authentikat/jwt/JsonWebTokenSpec.scala
@@ -75,6 +75,14 @@ class JsonWebTokenSpec extends FunSpec with ShouldMatchers {
       val jwt = JsonWebToken.apply(header, claims, "secretkey")
       JsonWebToken.validate(jwt, "here be dragons") should equal(false)
     }
+
+    it("should report validation failure and not crash if the token is incorrectly formatted") {
+      JsonWebToken.validate("", "secretkey") should equal(false)
+    }
+
+    it("should report a validation failure and not crash if the token components are incorrectly formatted") {
+      JsonWebToken.validate("..", "secretkey") should equal(false)
+    }
   }
 
   describe("JwtHeader") {


### PR DESCRIPTION
Address issue #8 - exceptions are no longer thrown by validate or unapply.