### PR TITLE
Removed transitive dep on scala-compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "authentikat-jwt"
 
 organization := "com.jason-goodwin"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.4", "2.11.2") //sbt '+ publish'
+crossScalaVersions := Seq("2.10.4", "2.11.7") //sbt '+ publish'
 
 parallelExecution := false
 
@@ -12,9 +12,9 @@ scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 libraryDependencies ++= Seq(
   "commons-codec" % "commons-codec" % "1.9",
-  "org.json4s" %% "json4s-native" % "3.2.10",
-  "org.json4s" %% "json4s-jackson" % "3.2.10",
-  "org.scalatest" %% "scalatest" % "2.1.7" % "test"
+  "org.json4s" %% "json4s-native" % "3.3.0",
+  "org.json4s" %% "json4s-jackson" % "3.3.0",
+  "org.scalatest" %% "scalatest" % "2.2.5" % Test
 )
 
 credentials += Credentials(Path.userHome / ".mdialog.credentials")

--- a/src/main/scala/authentikat/jwt/JsonWebSignature.scala
+++ b/src/main/scala/authentikat/jwt/JsonWebSignature.scala
@@ -24,7 +24,7 @@ object JsonWebSignature {
       case "HS256" => apply(HS256, data, key)
       case "HS384" => apply(HS384, data, key)
       case "HS512" => apply(HS512, data, key)
-      case "none" => apply(none, data, key)
+      case "none" => apply(NONE, data, key)
       case x => throw new UnsupportedOperationException(x + " is an unknown or unimplemented JWT algo key")
     }
   }
@@ -34,7 +34,7 @@ object JsonWebSignature {
       case HS256 => HmacSha("HmacSHA256", data, key)
       case HS384 => HmacSha("HmacSHA384", data, key)
       case HS512 => HmacSha("HmacSHA512", data, key)
-      case none => Array.empty[Byte]
+      case NONE => Array.empty[Byte]
       case x => throw new UnsupportedOperationException(x + " is an unknown or unimplemented JWT algo key")
     }
   }
@@ -52,7 +52,7 @@ object JsonWebSignature {
 
   abstract class Algorithm
 
-  case object none extends Algorithm
+  case object NONE extends Algorithm
 
   case object HS256 extends Algorithm
 

--- a/src/test/scala/authentikat/jwt/JsonWebSignatureSpec.scala
+++ b/src/test/scala/authentikat/jwt/JsonWebSignatureSpec.scala
@@ -9,7 +9,7 @@ class JsonWebSignatureSpec extends FunSpec with Matchers {
 
   describe("JsonWebSignature") {
     it("Should generate nothing for algo = none ") {
-      JsonWebSignature(none, "someData", "secretKey") should equal(Array.empty[Byte])
+      JsonWebSignature(NONE, "someData", "secretKey") should equal(Array.empty[Byte])
     }
 
     it("Should generate data for HMAC SHA 256 algorithm") {


### PR DESCRIPTION
* Removed transitive dependency on `scala-compiler` (via `json4s`)
* Move to latest scala version `2.11.7` and scalatest `2.2.5`
* Renamed `none` algorithm to `NONE` because of 'unreachable code due to variable pattern' warning message