### PR TITLE
Overload validate to accept header

### DIFF
--- a/src/main/scala/authentikat/jwt/JsonWebToken.scala
+++ b/src/main/scala/authentikat/jwt/JsonWebToken.scala
@@ -90,5 +90,30 @@ object JsonWebToken extends JsonMethods {
     }
   }
 
+  /**
+   * Validate a JWT claims set against a secret key.
+   * Note this does NOT validate exp or other validation claims - it only validates the claims against the hash.
+   * @param jwt
+   * @param header
+   * @param key
+   * @return
+   */
+
+  def validate(jwt: String, header: JwtHeader, key: String): Boolean = {
+
+    import org.json4s.DefaultFormats
+    implicit val formats = DefaultFormats
+
+    jwt.split("\\.") match {
+      case Array(providedHeader, providedClaims, providedSignature) ⇒
+
+        val signature = encodeBase64URLSafeString(
+          JsonWebSignature(header.algorithm.getOrElse("none"), providedHeader + "." + providedClaims, key))
+
+        java.security.MessageDigest.isEqual(providedSignature.getBytes(), signature.getBytes())
+      case _ ⇒
+        false
+    }
+  }
 }
 

--- a/src/test/scala/authentikat/jwt/JsonWebTokenSpec.scala
+++ b/src/test/scala/authentikat/jwt/JsonWebTokenSpec.scala
@@ -86,6 +86,26 @@ class JsonWebTokenSpec extends FunSpec with Matchers {
     it("should report a validation failure and not crash if the token components are incorrectly formatted") {
       JsonWebToken.validate("..", "secretkey") should equal(false)
     }
+
+    describe("validate with header") {
+      it("should validate a token successfully if same key is used") {
+        val jwt = JsonWebToken.apply(header, claims, "secretkey")
+        JsonWebToken.validate(jwt, header, "secretkey") should equal(true)
+      }
+
+      it("should fail to validate a token if different key is used") {
+        val jwt = JsonWebToken.apply(header, claims, "secretkey")
+        JsonWebToken.validate(jwt, header, "here be dragons") should equal(false)
+      }
+
+      it("should report validation failure and not crash if the token is incorrectly formatted") {
+        JsonWebToken.validate("", header, "secretkey") should equal(false)
+      }
+
+      it("should report a validation failure and not crash if the token components are incorrectly formatted") {
+        JsonWebToken.validate("..", header, "secretkey") should equal(false)
+      }
+    }
   }
 
   describe("JwtHeader") {


### PR DESCRIPTION
@jasongoodwin thanks for the great work. 

In our use-case we always validate the token after we extracted it. I noticed that there is some duplication in that case, since it will decode and parse the header twice. Passing the (already known) header into `validate` reduces runtime by about 10%. 